### PR TITLE
Fixed interval check

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,12 +31,11 @@ module.exports = function(opts, cb) {
   }
   var log = opts.log || console.log
   var tries = 0
-  var intervalId = setInterval(function() {
+  var check = function() {
     request(opts.url, function(err, response) {
       tries++
       if (!err && statusCheck(response)) {
         log("Got HTTP GET on " + opts.url + " indicating server is up")
-        clearInterval(intervalId)
         return cb(null)
       } else {
         log("Error on " + opts.url + ": " + err)
@@ -44,11 +43,14 @@ module.exports = function(opts, cb) {
           var msg = ("HTTP GET check on " + opts.url + " failed after " + tries
             + " tries, server not up - failing test")
           log(msg)
-          clearInterval(intervalId)
           return cb(msg, null)
         }
       }
+      waitCheck()
     })
-  }, checkInterval)
-  return intervalId
+  }
+  var waitCheck = function() {
+    return setTimeout(check, checkInterval)
+  }
+  return waitCheck()
 }


### PR DESCRIPTION
There is a race condition if server replies slower than the checkInterval time frame.

This example shows when it goes wrong and the pull request fixes it. Fixed this by using setTimeout after a request instead of using setInterval.

``` js
var check = require('httpcheck');
var assert = require('assert');
var http = require('http');

http.createServer(function(request, response) {
    setTimeout(function() {
        response.end();
    }, 1000);
}).listen(13532, function() {
    var checks = 0;
    check({
        url: 'http://localhost:13532',
        checkTries: 3,
        checkInterval: 500
    }, function() {
        checks++;
        assert(checks === 1);
    });
});
```
