### PR TITLE
Added timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ function(opts, cb)
 - `url`: URL to run HTTP check against. Required.
 - `checkTries`: Number of times to try the HTTP check. Default is 10.
 - `checkInterval`: Interval between HTTP check tries in ms. Default is 1000ms (1 second)
+- `checkTimeout`: Timeout for the HTTP check in ms. Default is 30000ms (30 seconds)
 - `check`: Custom check function which accepts a HTTP response object and returns
 `true` or `false` on success or failure. Default is that response object is truthy.
 - `log`: Custom log function. Default is `console.log`.

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var HTTP_CHECK_TRIES = 10
 // Default interval in between HTTP checks in ms
 var HTTP_CHECK_INTERVAL = 1000
 
+// Default time to wait before timeout
+var HTTP_CHECK_TIMEOUT = 30000
+
 //
 // **opts** an object with options
 //  - url: URL to check
@@ -23,6 +26,10 @@ module.exports = function(opts, cb) {
   if (opts.checkInterval === undefined) {
     checkInterval = HTTP_CHECK_INTERVAL
   }
+  var checkTimeout = opts.checkTimeout
+  if (opts.checkTimeout === undefined) {
+    checkTimeout = HTTP_CHECK_TIMEOUT
+  }
   var statusCheck = opts.check || function(response) {
     return response ? true : false
   }
@@ -32,7 +39,7 @@ module.exports = function(opts, cb) {
   var log = opts.log || console.log
   var tries = 0
   var check = function() {
-    request(opts.url, function(err, response) {
+    request(opts.url, {timeout:checkTimeout}, function(err, response) {
       tries++
       if (!err && statusCheck(response)) {
         log("Got HTTP GET on " + opts.url + " indicating server is up")


### PR DESCRIPTION
To avoid a request hanging endlessly it would be great to be able to forward a timeout parameter to the request module.

With this addition you can set a timeout value (defaults to 30 seconds), like this:

``` js
check({
    url: 'http://localhost:12321/foo',
    checkTimeout: 5000
}, callback);
```
